### PR TITLE
[DNM] jdbc: merge_direct mode for IBM DB2

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
@@ -58,7 +58,7 @@ public class JdbcOutputPlugin
         return new Features()
             .setMaxTableNameLength(t.getMaxTableNameLength())
             .setSupportedModes(Collections.unmodifiableSet(
-                    new HashSet<>(Arrays.asList(Mode.INSERT, Mode.INSERT_DIRECT, Mode.TRUNCATE_INSERT, Mode.REPLACE))));
+                    new HashSet<>(Arrays.asList(Mode.INSERT, Mode.INSERT_DIRECT, Mode.TRUNCATE_INSERT, Mode.REPLACE, Mode.MERGE_DIRECT))));
     }
 
     @Override

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -485,7 +485,8 @@ public abstract class AbstractJdbcOutputPlugin
             withRetry(task, new IdempotentSqlRunnable() {  // no intermediate data if isDirectModify == true
                 public void run() throws SQLException
                 {
-                    JdbcOutputConnection con = newConnection(task, true, false);
+                    // IBM DB2 requires explicit rollback/commit or AutoCommit to be enabled, so we pass `true` to the autoCommit argument.
+                    JdbcOutputConnection con = newConnection(task, true, true);
                     con.showDriverVersion();
                     try {
                         doBegin(con, task, schema, taskCount);

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -377,9 +377,9 @@ public class JdbcOutputConnection
         // The SQL string created here looks like this:
         // MERGE INTO `table-name` USING (
         //     VALUES (
-        //         ?,
-        //         ?,
-        //         ?
+        //         CAST(? AS `type-name`),
+        //         CAST(? AS `type-name`),
+        //         CAST(? AS `type-name`)
         //     )
         // ) AS tmp (
         //     `column-name1`,
@@ -409,7 +409,14 @@ public class JdbcOutputConnection
             if (i != 0) {
                 sb.append(", ");
             }
-            sb.append("?");
+            JdbcColumn column = toTableSchema.getColumn(i);
+            String typeName;
+            if (column.getSimpleTypeName().equals("VARCHAR")) {
+                typeName = column.getSimpleTypeName() + "(" + column.getSizeTypeParameter() + ")";
+            } else {
+                typeName = column.getSimpleTypeName();
+            }
+            sb.append("CAST(? AS " + typeName + ")");
         }
         sb.append(" )");
         sb.append(" ) AS tmp (");

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
@@ -86,6 +86,8 @@ public class StandardBatchInsert
             logger.info(String.format("> %.2f seconds (loaded %,d rows in total)", seconds, totalRows));
 
         } catch (BatchUpdateException e) {
+            // Output the exception message further to provide a detailed cause.
+            logger.error(e.getNextException().getMessage());
             // will be used for retry
             lastUpdateCounts = e.getUpdateCounts();
             throw e;


### PR DESCRIPTION
Added `merge_direct` mode for IBM DB2. The changes introduced by this PR are dedicated to DB2, so do not use this for other RDBMS, otherwise some errors may occur. 😉 